### PR TITLE
Amareleo chain/json cfg

### DIFF
--- a/amareleo-chain/Cargo.lock
+++ b/amareleo-chain/Cargo.lock
@@ -7,6 +7,7 @@ name = "amareleo-chain"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "crossterm",
  "homedir",
  "serde",
@@ -26,6 +27,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -85,6 +134,52 @@ dependencies = [
  "serde",
  "windows-targets 0.48.5",
 ]
+
+[[package]]
+name = "clap"
+version = "4.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "core-foundation-sys"
@@ -207,6 +302,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "homedir"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,7 +317,7 @@ dependencies = [
  "nix",
  "serde",
  "widestring",
- "windows-sys",
+ "windows-sys 0.48.0",
  "wmi",
 ]
 
@@ -304,7 +405,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -372,9 +473,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -481,9 +582,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b187f0231d56fe41bfb12034819dd2bf336422a5866de41bc3fec4b2e3883e8"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -521,6 +628,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "wasi"
@@ -660,6 +773,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]

--- a/amareleo-chain/Cargo.lock
+++ b/amareleo-chain/Cargo.lock
@@ -9,6 +9,8 @@ dependencies = [
  "anyhow",
  "crossterm",
  "homedir",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -46,9 +48,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "bumpalo"
@@ -96,7 +98,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "crossterm_winapi",
  "libc",
  "mio",
@@ -171,7 +173,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -242,10 +244,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "js-sys"
-version = "0.3.66"
+name = "itoa"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -390,6 +398,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,7 +426,18 @@ checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -456,20 +481,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2593d31f82ead8df961d8bd23a64c2ccf2eb5dd34b0a34bfb4dd54011c72009e"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
+checksum = "3b187f0231d56fe41bfb12034819dd2bf336422a5866de41bc3fec4b2e3883e8"
 
 [[package]]
 name = "syn"
@@ -499,7 +513,7 @@ checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -516,9 +530,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -526,24 +540,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -551,22 +565,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "widestring"
@@ -598,13 +612,14 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
+ "windows-core",
  "windows-implement",
  "windows-interface",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -618,24 +633,24 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e2ee588991b9e7e6c8338edf3333fbe4da35dc72092643958ebb43f0ab2c49c"
+checksum = "12168c33176773b86799be25e2a2ba07c7aab9968b37541f1094dbd7a60c8946"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6fb8df20c9bcaa8ad6ab513f7b40104840c8867d5751126e4df3b08388d0cc7"
+checksum = "9d8dc32e0095a7eeccebd0e3f09e9509365ecb3fc6ac4d6f5f14a3f6392942d1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -763,9 +778,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "wmi"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced703d10188571ce53582c2932ce640ed3c413cff7ee6e2d961f9abdb6a63d1"
+checksum = "fff298e96fd8ef6bb55dcb2a7fd2f26969f962bf428ffa6b267457dd804d64d8"
 dependencies = [
  "chrono",
  "futures",

--- a/amareleo-chain/Cargo.toml
+++ b/amareleo-chain/Cargo.toml
@@ -9,3 +9,5 @@ edition = "2021"
 homedir = "0.2.1"
 anyhow = "1"
 crossterm = "0.27.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/amareleo-chain/Cargo.toml
+++ b/amareleo-chain/Cargo.toml
@@ -11,3 +11,4 @@ anyhow = "1"
 crossterm = "0.27.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+clap = { version = "4.4.18", features = ["derive"] }

--- a/amareleo-chain/README.md
+++ b/amareleo-chain/README.md
@@ -52,4 +52,4 @@ Once ready hit q to terminate amareleo-chain.
 
 ## What Next?
 
-There is more we would like to add. We want to tool to be fully configurable such that if snarkOS changes one would get the tool running by tweaking a JSON configuration file. We also want the tool to start showing critical information like the processing of transactions and the mining of new blocks whilst filtering out other information. Stay tuned and post an issue if you would like to add more functionality.
+There is more we would like to add. We want the tool to be fully configurable such that if snarkOS changes one would get the tool running by tweaking a JSON configuration file. We also want the tool to start showing critical information like the processing of transactions and the mining of new blocks whilst filtering out other information. Stay tuned and post an issue if you would like to add more functionality.

--- a/amareleo-chain/src/app_args.rs
+++ b/amareleo-chain/src/app_args.rs
@@ -1,0 +1,51 @@
+use clap::{Args, Parser, Subcommand};
+
+const CMD_INIT: &str = "init";
+const CMD_RUN: &str = "run";
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct AppCmds {
+    #[clap(subcommand)]
+    pub cmd_type: Option<AppCmdType>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum AppCmdType {
+    /// Generate default configuration
+    Init(InitArgs),
+
+    /// Run the amareleo-chain
+    Run(RunArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct InitArgs {
+    /// Path to json configuration
+    #[arg(long, short)]
+    pub cfg: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct RunArgs {
+    /// Path to json configuration
+    #[arg(long, short)]
+    pub cfg: Option<String>,
+
+    /// Path under which the ledger folders are created.
+    #[arg(long, short)]
+    pub ledger: Option<String>,
+}
+
+pub fn cmd_usage() {
+    println!(
+        r#"
+
+Examples:
+
+amareleo-chain {CMD_INIT} --cfg ~/mycfg.json
+
+amareleo-chain {CMD_RUN}  --cfg ~/mycfg.json  --ledger  ~/chain
+"#
+    );
+}

--- a/amareleo-chain/src/app_args.rs
+++ b/amareleo-chain/src/app_args.rs
@@ -24,6 +24,10 @@ pub struct InitArgs {
     /// Path to json configuration
     #[arg(long, short)]
     pub cfg: Option<String>,
+
+    /// Force writing even if config already exists
+    #[arg(long, short)]
+    pub force: bool,
 }
 
 #[derive(Debug, Args)]

--- a/amareleo-chain/src/chain_errors.rs
+++ b/amareleo-chain/src/chain_errors.rs
@@ -19,6 +19,15 @@ pub enum ChainErrors {
 
     /// Cannot find process ready phrase
     CannotFindReady,
+
+    /// Node Configuration Not Found.
+    ConfigNodesNotFound,
+
+    /// Node Configuration only supports up to 10 nodes.
+    ConfigTooManyNodes,
+
+    /// --dev parameter must NOT be configured
+    ConfigRemoveDevArg,
 }
 
 impl fmt::Display for ChainErrors {

--- a/amareleo-chain/src/config/chain_cfg.rs
+++ b/amareleo-chain/src/config/chain_cfg.rs
@@ -41,8 +41,12 @@ impl ChainArgs {
         Ok(())
     }
 
-    pub fn load() -> anyhow::Result<ChainArgs> {
-        let cfg_path = create_amareleo_dir()?.join(AMARELEO_CHAIN_CFG);
+    pub fn load(path: &Option<String>) -> anyhow::Result<ChainArgs> {
+        let cfg_path = match path {
+            Some(apath) => file_exists(apath)?,
+            None => create_amareleo_dir()?.join(AMARELEO_CHAIN_CFG),
+        };
+
         if !cfg_path.exists() {
             ChainArgs::init(&cfg_path)?;
         }
@@ -101,7 +105,36 @@ pub fn default_node_args(num: usize, all: bool) -> Vec<String> {
     args
 }
 
+pub fn folder_exists(path: &str) -> anyhow::Result<PathBuf> {
+    let folder = PathBuf::from(path);
+
+    if !folder.exists() || !folder.is_dir() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Folder path not found",
+        ))
+        .context("Finding ledger base directory.");
+    }
+
+    Ok(folder)
+}
+
+pub fn file_exists(path: &str) -> anyhow::Result<PathBuf> {
+    let file = PathBuf::from(path);
+
+    if !file.exists() || !file.is_file() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "File path not found",
+        ))
+        .context("Finding configuration file.");
+    }
+
+    Ok(file)
+}
+
 pub fn create_amareleo_dir() -> anyhow::Result<PathBuf> {
+    //Cross-platform compatible retreival of the user's home dir
     let home_path: PathBuf = match get_my_home()?.take() {
         None => return Err(ChainErrors::NoHomeDir.into()),
         Some(path) => path,

--- a/amareleo-chain/src/config/chain_cfg.rs
+++ b/amareleo-chain/src/config/chain_cfg.rs
@@ -1,0 +1,157 @@
+use crate::chain_errors::ChainErrors;
+use crate::config::*;
+
+use std::fs::File;
+use std::fs::{create_dir, remove_dir_all};
+use std::io::Read;
+use std::path::PathBuf;
+
+use anyhow::{Context, Ok};
+use homedir::get_my_home;
+
+impl ChainArgs {
+    pub fn init(json_path: &PathBuf) -> anyhow::Result<()> {
+        let cfg = ChainArgs {
+            snarkos: vec![
+                NodeArgs {
+                    node: default_node_args(0, false),
+                    started: String::from(NODE0_START_COMPLETE),
+                },
+                NodeArgs {
+                    node: default_node_args(1, false),
+                    started: String::from(NODE1_START_COMPLETE),
+                },
+                NodeArgs {
+                    node: default_node_args(2, false),
+                    started: String::from(NODE2_START_COMPLETE),
+                },
+                NodeArgs {
+                    node: default_node_args(3, false),
+                    started: String::from(NODE3_START_COMPLETE),
+                },
+            ],
+        };
+
+        // Open the file for writing
+        let json_file = File::create(json_path)?;
+
+        // Serialize the data to the file
+        serde_json::to_writer(json_file, &cfg)?;
+
+        Ok(())
+    }
+
+    pub fn load() -> anyhow::Result<ChainArgs> {
+        let cfg_path = create_amareleo_dir()?.join(AMARELEO_CHAIN_CFG);
+        if !cfg_path.exists() {
+            ChainArgs::init(&cfg_path)?;
+        }
+
+        let mut cfg_file = File::open(cfg_path)?;
+        let mut raw_cfg = String::new();
+
+        cfg_file.read_to_string(&mut raw_cfg)?;
+        let mut json: ChainArgs = serde_json::from_str(&raw_cfg)?;
+
+        // Make sure we have at least one node configured
+        if json.snarkos.is_empty() {
+            return Err(ChainErrors::ConfigNodesNotFound.into());
+        }
+
+        // Make sure we don't have more than 10 nodes configured
+        if json.snarkos.len() > 10 {
+            return Err(ChainErrors::ConfigTooManyNodes.into());
+        }
+
+        // Make sure none of the configurations includes the --dev argument
+        for cfgnode in json.snarkos.iter() {
+            for param in cfgnode.node.iter() {
+                if param.to_ascii_lowercase().trim() == "--dev" {
+                    return Err(ChainErrors::ConfigRemoveDevArg.into());
+                }
+            }
+        }
+
+        //Insert the --dev parameter
+        for (idx, cfgnode) in json.snarkos.iter_mut().enumerate() {
+            cfgnode.node.push(String::from("--dev"));
+            cfgnode.node.push(idx.to_string());
+        }
+
+        Ok(json)
+    }
+}
+
+pub fn default_node_args(num: usize, all: bool) -> Vec<String> {
+    let mut args: Vec<String> = vec![
+        String::from("start"),
+        String::from("--nodisplay"),
+        String::from("--validator"),
+    ];
+
+    if num != 0 {
+        args.push(String::from("--norest"));
+    }
+
+    if all {
+        args.push(String::from("--dev"));
+        args.push(num.to_string());
+    }
+
+    args
+}
+
+pub fn create_amareleo_dir() -> anyhow::Result<PathBuf> {
+    let home_path: PathBuf = match get_my_home()?.take() {
+        None => return Err(ChainErrors::NoHomeDir.into()),
+        Some(path) => path,
+    };
+
+    if !home_path.exists() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Home path not found",
+        ))
+        .context("Failed to create ledger directory");
+    }
+
+    if !home_path.is_dir() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "Home path is not a directory",
+        ))
+        .context("Failed to create ledger directory");
+    }
+
+    let amareleo_path = home_path.join(AMARELEO_HOME_DIR);
+    if !amareleo_path.exists() {
+        create_dir(&amareleo_path)?;
+    }
+
+    Ok(amareleo_path)
+}
+
+pub fn create_ledger_dir() -> anyhow::Result<PathBuf> {
+    let amareleo_path = create_amareleo_dir()?;
+
+    let chain_path = amareleo_path.join(AMARELEO_CHAIN_DIR);
+    if chain_path.exists() {
+        remove_dir_all(&chain_path)?;
+    }
+    create_dir(&chain_path)?;
+
+    Ok(chain_path)
+}
+
+pub fn clear_ledger_dir(path: &PathBuf) -> anyhow::Result<()> {
+    if !path.exists() || !path.is_dir() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Chain Path not found",
+        ))
+        .context("Failed to clear ledger.");
+    }
+
+    remove_dir_all(path)?;
+    Ok(())
+}

--- a/amareleo-chain/src/config/mod.rs
+++ b/amareleo-chain/src/config/mod.rs
@@ -1,0 +1,26 @@
+mod chain_cfg;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+pub use chain_cfg::*;
+
+pub const AMARELEO_HOME_DIR: &str = ".amareleo";
+pub const AMARELEO_CHAIN_DIR: &str = "chain";
+pub const AMARELEO_CHAIN_CFG: &str = "chain-cfg.json";
+
+pub const NODE0_START_COMPLETE: &str = "No connected validators";
+pub const NODE1_START_COMPLETE: &str = "Connected to 1 validators";
+pub const NODE2_START_COMPLETE: &str = "Connected to 2 validators";
+pub const NODE3_START_COMPLETE: &str = "Advanced to block";
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct NodeArgs {
+    pub node: Vec<String>,
+    pub started: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ChainArgs {
+    pub snarkos: Vec<NodeArgs>,
+}

--- a/amareleo-chain/src/main.rs
+++ b/amareleo-chain/src/main.rs
@@ -1,4 +1,5 @@
 mod chain_errors;
+mod config;
 mod console;
 mod node;
 mod node_batch;
@@ -6,6 +7,7 @@ mod node_batch;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use config::ChainArgs;
 use console::ConsoleManager;
 use crossterm::event::{self, KeyCode};
 use node_batch::NodeSet;
@@ -14,15 +16,26 @@ fn main() {
     let mut base_console = ConsoleManager::start(20);
     base_console.status("Starting nodes...");
 
-    let console = Arc::new(Mutex::new(base_console));
+    let chain_cfg = match ChainArgs::load() {
+        Err(err) => {
+            base_console.batch_report(
+                "main",
+                None,
+                &["ERROR on loading config", &err.to_string(), ""],
+            );
+            return;
+        }
+        Ok(cfg) => cfg,
+    };
 
-    let mut nodes = NodeSet::new(&console);
+    let console = Arc::new(Mutex::new(base_console));
+    let mut nodes = NodeSet::new(chain_cfg, &console);
     match nodes.start() {
         Ok(_) => {
             report!(
                 console,
                 "main",
-                Some("q - quit | (0, 1, 2, 3) - node dump | s - silent"),
+                Some("q - quit | (0, 1, 2...) - node log | s - silent"),
                 "",
                 "All nodes started!",
                 ""
@@ -45,6 +58,12 @@ fn main() {
                         KeyCode::Char('1') => nodes.stdout_show(1),
                         KeyCode::Char('2') => nodes.stdout_show(2),
                         KeyCode::Char('3') => nodes.stdout_show(3),
+                        KeyCode::Char('4') => nodes.stdout_show(4),
+                        KeyCode::Char('5') => nodes.stdout_show(5),
+                        KeyCode::Char('6') => nodes.stdout_show(6),
+                        KeyCode::Char('7') => nodes.stdout_show(7),
+                        KeyCode::Char('8') => nodes.stdout_show(8),
+                        KeyCode::Char('9') => nodes.stdout_show(9),
 
                         _ => {}
                     }

--- a/amareleo-chain/src/main.rs
+++ b/amareleo-chain/src/main.rs
@@ -5,13 +5,14 @@ mod console;
 mod node;
 mod node_batch;
 
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
 
 use app_args::*;
 use clap::Parser;
 
-use config::ChainArgs;
+use config::*;
 use console::ConsoleManager;
 use crossterm::event::{self, KeyCode};
 use node_batch::NodeSet;
@@ -88,6 +89,66 @@ fn run(args: &RunArgs) {
     }
 }
 
+fn init(args: &InitArgs) {
+    let mut base_console = ConsoleManager::start(20);
+    base_console.status("Initializing config...");
+
+    let cfg_path: anyhow::Result<PathBuf> = match &args.cfg {
+        Some(apath) => Ok(PathBuf::from(apath)),
+        None => match create_amareleo_dir() {
+            Ok(default_dir) => Ok(default_dir.join(AMARELEO_CHAIN_CFG)),
+            Err(err) => {
+                base_console.batch_report(
+                    "main",
+                    Some("Failed"),
+                    &[
+                        "ERROR on initializing default config path",
+                        &err.to_string(),
+                        "",
+                    ],
+                );
+                Err(err)
+            }
+        },
+    };
+
+    if let Ok(path) = cfg_path {
+        if !args.force && path.exists() {
+            base_console.batch_report(
+                "main",
+                Some("Failed"),
+                &[
+                    "ERROR config already exists. Use --force to overwrite",
+                    path.to_str().unwrap(),
+                    "",
+                ],
+            );
+
+            return;
+        }
+
+        match ChainArgs::init(&path) {
+            Err(err) => base_console.batch_report(
+                "main",
+                Some("Failed"),
+                &[
+                    "ERROR on initializing config",
+                    &err.to_string(),
+                    path.to_str().unwrap(),
+                    "",
+                ],
+            ),
+            Ok(_) => {
+                base_console.batch_report(
+                    "main",
+                    Some("Ready"),
+                    &["Configuration initialized", path.to_str().unwrap(), ""],
+                );
+            }
+        }
+    }
+}
+
 fn main() {
     let params = AppCmds::try_parse();
 
@@ -104,7 +165,7 @@ fn main() {
     };
 
     match params {
-        AppCmdType::Init(_) => {}
+        AppCmdType::Init(args) => init(&args),
         AppCmdType::Run(args) => run(&args),
     }
 }

--- a/amareleo-chain/src/main.rs
+++ b/amareleo-chain/src/main.rs
@@ -1,3 +1,4 @@
+mod app_args;
 mod chain_errors;
 mod config;
 mod console;
@@ -7,16 +8,19 @@ mod node_batch;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use app_args::*;
+use clap::Parser;
+
 use config::ChainArgs;
 use console::ConsoleManager;
 use crossterm::event::{self, KeyCode};
 use node_batch::NodeSet;
 
-fn main() {
+fn run(args: &RunArgs) {
     let mut base_console = ConsoleManager::start(20);
     base_console.status("Starting nodes...");
 
-    let chain_cfg = match ChainArgs::load() {
+    let chain_cfg = match ChainArgs::load(&args.cfg) {
         Err(err) => {
             base_console.batch_report(
                 "main",
@@ -30,7 +34,7 @@ fn main() {
 
     let console = Arc::new(Mutex::new(base_console));
     let mut nodes = NodeSet::new(chain_cfg, &console);
-    match nodes.start() {
+    match nodes.start(&args.ledger) {
         Ok(_) => {
             report!(
                 console,
@@ -81,6 +85,27 @@ fn main() {
                 ""
             );
         }
+    }
+}
+
+fn main() {
+    let params = AppCmds::try_parse();
+
+    let params = match params {
+        Ok(res) => res.cmd_type.unwrap_or(AppCmdType::Run(RunArgs {
+            cfg: None,
+            ledger: None,
+        })),
+        Err(err) => {
+            let _ = err.print();
+            cmd_usage();
+            return;
+        }
+    };
+
+    match params {
+        AppCmdType::Init(_) => {}
+        AppCmdType::Run(args) => run(&args),
     }
 }
 

--- a/amareleo-chain/src/node/mod.rs
+++ b/amareleo-chain/src/node/mod.rs
@@ -16,6 +16,9 @@ pub struct SnarkNode<'a> {
     // Friendly process name
     name: String,
 
+    // snarkos arguments
+    args: Vec<String>,
+
     // A phrase that indicates that the process started and has
     // completed initialization.
     ready_phrase: String,

--- a/amareleo-chain/src/node/snark_node.rs
+++ b/amareleo-chain/src/node/snark_node.rs
@@ -8,15 +8,21 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::chain_errors::ChainErrors;
+use crate::config::NodeArgs;
 use crate::console::ConsoleManager;
 use crate::node::SnarkNode;
 use crate::report;
 
 impl<'a> SnarkNode<'a> {
-    pub fn new(name: &str, ready: &str, console: &'a Arc<Mutex<ConsoleManager>>) -> SnarkNode<'a> {
+    pub fn new(
+        cfg: NodeArgs,
+        name: &str,
+        console: &'a Arc<Mutex<ConsoleManager>>,
+    ) -> SnarkNode<'a> {
         SnarkNode {
             name: name.to_string(),
-            ready_phrase: ready.to_string(),
+            args: cfg.node,
+            ready_phrase: cfg.started,
             process: None,
             stdout_reader: None,
             stdout_thread: None,
@@ -25,12 +31,7 @@ impl<'a> SnarkNode<'a> {
         }
     }
 
-    fn start_process(
-        &mut self,
-        start_path: &PathBuf,
-        params: Vec<String>,
-        time_limit_secs: u64,
-    ) -> anyhow::Result<()> {
+    fn start_process(&mut self, start_path: &PathBuf, time_limit_secs: u64) -> anyhow::Result<()> {
         if self.process.is_some() {
             return Err(ChainErrors::ProcessAlreadyStarted.into());
         }
@@ -38,7 +39,7 @@ impl<'a> SnarkNode<'a> {
         let start_time = Instant::now();
 
         let mut snarkos = Command::new("snarkos")
-            .args(params)
+            .args(&self.args)
             .stdout(Stdio::piped())
             .current_dir(start_path)
             .spawn()?;
@@ -149,13 +150,8 @@ impl<'a> SnarkNode<'a> {
         Ok(())
     }
 
-    pub fn start(
-        &mut self,
-        start_path: &PathBuf,
-        params: Vec<String>,
-        time_limit_secs: u64,
-    ) -> anyhow::Result<()> {
-        self.start_process(start_path, params, time_limit_secs)?;
+    pub fn start(&mut self, start_path: &PathBuf, time_limit_secs: u64) -> anyhow::Result<()> {
+        self.start_process(start_path, time_limit_secs)?;
         self.consume_stdout()
     }
 

--- a/amareleo-chain/src/node_batch/mod.rs
+++ b/amareleo-chain/src/node_batch/mod.rs
@@ -5,14 +5,6 @@ use std::path::PathBuf;
 
 pub use node_set::*;
 
-pub const AMARELEO_HOME_DIR: &str = ".amareleo";
-pub const AMARELEO_CHAIN_DIR: &str = "chain";
-
-pub const NODE0_START_COMPLETE: &str = "No connected validators";
-pub const NODE1_START_COMPLETE: &str = "Connected to 1 validators";
-pub const NODE2_START_COMPLETE: &str = "Connected to 2 validators";
-pub const NODE3_START_COMPLETE: &str = "Advanced to block";
-
 pub struct NodeSet<'a> {
     // Path to chain storage
     chain_path: PathBuf,

--- a/amareleo-chain/src/node_batch/mod.rs
+++ b/amareleo-chain/src/node_batch/mod.rs
@@ -9,6 +9,9 @@ pub struct NodeSet<'a> {
     // Path to chain storage
     chain_path: PathBuf,
 
+    // clear chain storage
+    clear: bool,
+
     // List of node instances
     nodes: Vec<SnarkNode<'a>>,
 }

--- a/amareleo-chain/src/node_batch/node_set.rs
+++ b/amareleo-chain/src/node_batch/node_set.rs
@@ -18,13 +18,18 @@ impl<'a> NodeSet<'a> {
 
         NodeSet {
             chain_path: PathBuf::new(),
+            clear: false,
             nodes: node_list,
         }
     }
 
-    pub fn start(&mut self) -> anyhow::Result<()> {
-        //Cross-platform compatible retreival of the user's home dir
-        self.chain_path = create_ledger_dir()?;
+    pub fn start(&mut self, ledger: &Option<String>) -> anyhow::Result<()> {
+        self.chain_path = if let Some(path) = ledger {
+            folder_exists(path)?
+        } else {
+            self.clear = true;
+            create_ledger_dir()?
+        };
 
         for node in self.nodes.iter_mut() {
             node.start(&self.chain_path, 300u64)?;
@@ -40,7 +45,10 @@ impl<'a> NodeSet<'a> {
             let _ = node.end();
         }
 
-        let _ = clear_ledger_dir(&self.chain_path);
+        // Only clear if user didn't override the ledger storge path
+        if self.clear {
+            let _ = clear_ledger_dir(&self.chain_path);
+        }
     }
 
     pub fn stdout_silent(&mut self) {

--- a/amareleo-chain/src/node_batch/node_set.rs
+++ b/amareleo-chain/src/node_batch/node_set.rs
@@ -1,27 +1,24 @@
-use crate::chain_errors::ChainErrors;
+use crate::config::*;
 use crate::console::ConsoleManager;
 use crate::node::SnarkNode;
 use crate::node_batch::*;
 
-use std::fs::{create_dir, remove_dir_all};
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use anyhow::{Context, Ok};
-
-use homedir::get_my_home;
 use std::path::PathBuf;
 
 impl<'a> NodeSet<'a> {
-    pub fn new(console: &Arc<Mutex<ConsoleManager>>) -> NodeSet {
+    pub fn new(chain_cfg: ChainArgs, console: &Arc<Mutex<ConsoleManager>>) -> NodeSet {
+        let mut node_list = Vec::<SnarkNode>::new();
+
+        for (idx, node_cfg) in chain_cfg.snarkos.into_iter().enumerate() {
+            node_list.push(SnarkNode::new(node_cfg, &format!("node{idx}"), console));
+        }
+
         NodeSet {
             chain_path: PathBuf::new(),
-            nodes: vec![
-                SnarkNode::new("node0", NODE0_START_COMPLETE, console),
-                SnarkNode::new("node1", NODE1_START_COMPLETE, console),
-                SnarkNode::new("node2", NODE2_START_COMPLETE, console),
-                SnarkNode::new("node3", NODE3_START_COMPLETE, console),
-            ],
+            nodes: node_list,
         }
     }
 
@@ -29,8 +26,8 @@ impl<'a> NodeSet<'a> {
         //Cross-platform compatible retreival of the user's home dir
         self.chain_path = create_ledger_dir()?;
 
-        for (idx, node) in self.nodes.iter_mut().enumerate() {
-            node.start(&self.chain_path, default_node_args(idx), 300u64)?;
+        for node in self.nodes.iter_mut() {
+            node.start(&self.chain_path, 300u64)?;
         }
 
         Ok(())
@@ -63,70 +60,4 @@ impl<'a> Drop for NodeSet<'a> {
     fn drop(&mut self) {
         self.end();
     }
-}
-
-pub fn default_node_args(num: usize) -> Vec<String> {
-    let mut args: Vec<String> = vec![
-        String::from("start"),
-        String::from("--dev"),
-        num.to_string(),
-        String::from("--nodisplay"),
-        String::from("--validator"),
-    ];
-
-    if num != 0 {
-        args.push(String::from("--norest"));
-    }
-
-    args
-}
-
-pub fn create_ledger_dir() -> anyhow::Result<PathBuf> {
-    //Cross-platform compatible retreival of the user's home dir
-    let home_path: PathBuf = match get_my_home()?.take() {
-        None => return Err(ChainErrors::NoHomeDir.into()),
-        Some(path) => path,
-    };
-
-    if !home_path.exists() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            "Home path not found",
-        ))
-        .context("Failed to create ledger directory");
-    }
-
-    if !home_path.is_dir() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "Home path is not a directory",
-        ))
-        .context("Failed to create ledger directory");
-    }
-
-    let amareleo_path = home_path.join(AMARELEO_HOME_DIR);
-    if !amareleo_path.exists() {
-        create_dir(&amareleo_path)?;
-    }
-
-    let chain_path = amareleo_path.join(AMARELEO_CHAIN_DIR);
-    if chain_path.exists() {
-        remove_dir_all(&chain_path)?;
-    }
-    create_dir(&chain_path)?;
-
-    Ok(chain_path)
-}
-
-pub fn clear_ledger_dir(path: &PathBuf) -> anyhow::Result<()> {
-    if !path.exists() || !path.is_dir() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            "Chain Path not found",
-        ))
-        .context("Failed to clear ledger.");
-    }
-
-    remove_dir_all(path)?;
-    Ok(())
 }

--- a/amareleo-chain/src/tests.rs
+++ b/amareleo-chain/src/tests.rs
@@ -7,7 +7,7 @@ use crate::node::SnarkNode;
 
 #[test]
 fn test_start_node0() {
-    let mut chain_cfg = config::ChainArgs::load().unwrap();
+    let mut chain_cfg = config::ChainArgs::load(&None).unwrap();
 
     let base_console = ConsoleManager::start(10);
     let console = Arc::new(Mutex::new(base_console));

--- a/amareleo-chain/src/tests.rs
+++ b/amareleo-chain/src/tests.rs
@@ -1,22 +1,22 @@
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use crate::config;
 use crate::console::ConsoleManager;
 use crate::node::SnarkNode;
-use crate::node_batch;
 
 #[test]
 fn test_start_node0() {
+    let mut chain_cfg = config::ChainArgs::load().unwrap();
+
     let base_console = ConsoleManager::start(10);
     let console = Arc::new(Mutex::new(base_console));
-    let chain_path = node_batch::create_ledger_dir().unwrap();
 
-    let mut one_node: SnarkNode =
-        SnarkNode::new("node0", node_batch::NODE0_START_COMPLETE, &console);
+    let chain_path = config::create_ledger_dir().unwrap();
 
-    one_node
-        .start(&chain_path, node_batch::default_node_args(0), 300u64)
-        .unwrap();
+    let mut one_node: SnarkNode = SnarkNode::new(chain_cfg.snarkos.remove(0), "node0", &console);
+
+    one_node.start(&chain_path, 300u64).unwrap();
 
     let has_monitor = one_node.has_stdout_monitor();
     assert!(has_monitor);


### PR DESCRIPTION
## Updates
1. Support for json configuration file, through which we can set the parameters used when starting snarkOS.

1. Support for `init` and `run` commands

---

### JSON Configuration

amareleo-chain will automatically create the default config under:
~/.amareleo/chain-cfg.json

One may then directly edit this file to customize the snarkOS startup.

Alternatively one can create a fresh copy of the configuration file and pass it as a command-line parameter to amareleo-chain, overriding the default configuration path.

---

### init and run Commands

This update also introduces support for two commands `init` and `run`

Running `amareleo-chain init` the application will generate the default configuration json file.

Running `amareleo-chain run` the chain can be started with a custom configuration path and chain storage folder. When using a custom chain storage folder the application won't delete the chain on exit. Thus the chain state is retained across runs.

Running `amareleo-chain` without any parameters is equivalent to running `amareleo-chain run` without passing it any additional parameters.
